### PR TITLE
Launch procserv on demand

### DIFF
--- a/procServControlApp/src/Makefile
+++ b/procServControlApp/src/Makefile
@@ -22,5 +22,6 @@ procServControl_LIBS += asyn seq
 
 # We need to link against the EPICS Base libraries
 procServControl_LIBS += $(EPICS_BASE_IOC_LIBS)
+procServControl_SYS_LIBS_WIN32 += Userenv
 
 include $(TOP)/configure/RULES

--- a/procServControlApp/src/procServControl.st
+++ b/procServControlApp/src/procServControl.st
@@ -6,6 +6,8 @@ program procServControl("P=P")
 #ifdef _WIN32
 %% #include <windows.h>
 %% #include <process.h>
+%% #include <processthreadsapi.h>
+%% #include <userenv.h>
 #else
 %% #include <unistd.h>
 #endif /* ifdef _WIN32 */
@@ -59,6 +61,9 @@ int lastcommand;
 /* These are needed to tie up the ppasynUser with the state machine */
 int stateIndex;
 
+/* have we launched a procServ */
+int procserv_launched;
+
 /* we define two ports per ioc in build_ioc_startup, between ports 20000 and 49152
  * (port 49152 is start of IANA dynamic range for port allocation)
  * Therefore we can have at most ((49152 - 20000)/2) (=14576) iocs assuming all ports are free
@@ -71,6 +76,7 @@ int stateIndex;
 %% #include <asynOctetSyncIO.h>
 %% static asynUser* pasynUsers[NSTATEMACHINES];
 %% static void createAsynUser(struct UserVar *pVar);
+%% static void startProcserv(struct UserVar *pVar);
 %% static void getNextLine(struct UserVar *pVar);
 %% static void writeControlChar(struct UserVar *pVar, const char *controlChar);
 
@@ -94,7 +100,16 @@ ss ssUserInput {
         entry {
         }
 
-        when(efTestAndClear(startMon) && (start == 1)) {
+        when( (status == PROCSERVSTOPPED) && (procserv_launched == 0) && (
+                (efTest(startMon) && (start == 1)) ||
+                (efTest(stopMon) && (stop == 1)) ||
+                (efTest(restartMon) && (restart == 1)) ||
+                (efTest(toggleMon) && (toggle == 1)) ) ) {
+            startProcserv(pVar);
+            procserv_launched = 1;
+        } state MONITORINPUTS
+
+        when((status != PROCSERVSTOPPED) && efTestAndClear(startMon) && (start == 1)) {
             /* If we are shutdown then send CTRL-X to start */
             if (status == SHUTDOWN) {
                 %% writeControlChar(pVar, "\x18");
@@ -104,7 +119,7 @@ ss ssUserInput {
             efSet(statusMon); /* to avoid timeout if start when running */
         } state WAITFORRUNNING
 
-        when(efTestAndClear(stopMon) && (stop == 1)) {
+        when((status != PROCSERVSTOPPED) && efTestAndClear(stopMon) && (stop == 1)) {
             /* If we are running, then make sure autorestart is off, if it isn't
              * send CTRL-T, then send CTRL-X to stop */
             if (status == RUNNING) {
@@ -120,7 +135,7 @@ ss ssUserInput {
             efSet(statusMon); /* to avoid timeout if stop when stopped */
         } state WAITFORSHUTDOWN
 
-        when(efTestAndClear(restartMon) && (restart == 1)) {
+        when((status != PROCSERVSTOPPED) && efTestAndClear(restartMon) && (restart == 1)) {
             /* If we are running, then make sure autorestart is on, if it isn't
              * send CTRL-T, then send CTRL-X to restart */
             if (status == RUNNING) {
@@ -136,7 +151,7 @@ ss ssUserInput {
             efSet(statusMon); /* to avoid potential timeout error */
         } state WAITFORRESTART
 
-        when(efTestAndClear(toggleMon) && (toggle == 1)) {
+        when((status != PROCSERVSTOPPED) && efTestAndClear(toggleMon) && (toggle == 1)) {
             /* If we are running, then send CTRL-T to toggle autorestart */
             if (status == RUNNING) {
                 %% writeControlChar(pVar, "\x14");
@@ -434,6 +449,53 @@ static void writeControlChar(struct UserVar *pVar, const char *controlChar) {
     pasynOctetSyncIO->write(pasynUser, controlChar, 1, 1.0, &bytes);
 }
 
+/* start procserv. We do not want to inherit the process environment
+   as we are spawned from procServControl ioc and its environment can
+   confuse the ioc we create, hence the slightly convoluted process creation
+   to not inherit process variables but try to inherit user/system ones
+*/
+static void startProcserv(struct UserVar *pVar) {
+    asynUser *pasynUser;
+    const char* epics_kit_root = getenv("EPICS_KIT_ROOT");
+    char command[256];
+#ifdef _WIN32
+    const char* comspec = getenv("ComSpec");
+    LPVOID lpEnv = NULL;
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+    BOOL status;
+    DWORD dwCreationFlags = 0;
+    ZeroMemory( &si, sizeof(si) );
+    si.cb = sizeof(si);
+    ZeroMemory( &pi, sizeof(pi) );
+    if (epics_kit_root != NULL) {
+        sprintf(command, "\"%s\" /c \"%s\\iocstartup\\ioc_bats\\%s.bat\"", comspec, epics_kit_root, pVar->port);
+        printf("startProcserv: Running %s\n", command);
+        if (!CreateEnvironmentBlock(&lpEnv, GetCurrentProcessToken(), FALSE)) {
+            printf("startProcserv: Cannot create environment: error 0x%08x\n", GetLastError());
+            return;
+        }
+        dwCreationFlags |= CREATE_UNICODE_ENVIRONMENT; /* CreateEnvironmentBlock returns unicode */
+        status = CreateProcess(NULL, command, NULL, NULL, FALSE, dwCreationFlags, lpEnv, NULL, &si, &pi);
+        if (!status) {
+            printf("startProcserv: Cannot create process: error 0x%08x\n", GetLastError());
+        }
+        DestroyEnvironmentBlock(lpEnv);
+        if (!status) {
+            return;
+        }
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+
+        /* Check that asynUser exists */
+        if (pVar->stateIndex >= NSTATEMACHINES) return;
+        pasynUser = pasynUsers[pVar->stateIndex];
+        if (pasynUser == NULL) return;
+
+        /* enable autoconnect now we have launched procserv */
+        pasynManager->autoConnect(pasynUser, 1);
+    }
+#endif
+}
+
 }%
-
-


### PR DESCRIPTION
Add logic to launch procServ on demand on first call to start the IOC, this will reduce number of procServ needing to run on instruments

See ISISComputingGroup/IBEX#8558